### PR TITLE
remove unnecessary resize event listener.

### DIFF
--- a/js/monkeys.js
+++ b/js/monkeys.js
@@ -302,4 +302,3 @@ function onWindowResize() {
   camera.updateProjectionMatrix();
   effect.setSize( window.innerWidth, window.innerHeight );
 }
-window.addEventListener( 'resize', onWindowResize, false );


### PR DESCRIPTION
exists in _init()
